### PR TITLE
Needless measures to against timing attack

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -116,7 +116,7 @@ module JWT
   def verify_signature(algo, key, signing_input, signature)
     begin
       if ["HS256", "HS384", "HS512"].include?(algo)
-        raise JWT::DecodeError.new("Signature verification failed") unless secure_compare(signature, sign_hmac(algo, signing_input, key))
+        raise JWT::DecodeError.new("Signature verification failed") unless signature == sign_hmac(algo, signing_input, key)
       elsif ["RS256", "RS384", "RS512"].include?(algo)
         raise JWT::DecodeError.new("Signature verification failed") unless verify_rsa(algo, key, signing_input, signature)
       else
@@ -127,17 +127,6 @@ module JWT
     ensure
       OpenSSL.errors.clear
     end
-  end
-
-  # From devise
-  # constant-time comparison algorithm to prevent timing attacks
-  def secure_compare(a, b)
-    return false if a.nil? || b.nil? || a.empty? || b.empty? || a.bytesize != b.bytesize
-    l = a.unpack "C#{a.bytesize}"
-
-    res = 0
-    b.each_byte { |byte| res |= byte ^ l.shift }
-    res == 0
   end
 
 end

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -109,19 +109,6 @@ describe JWT do
     expect { JWT.decode(jwt, nil, true) }.to raise_error(JWT::DecodeError)
   end
 
-  it "does not use == to compare digests" do
-    secret = "secret"
-    jwt = JWT.encode(@payload, secret)
-    crypto_segment = jwt.split(".").last
-
-    signature = JWT.base64url_decode(crypto_segment)
-    expect(signature).not_to receive('==')
-    expect(JWT).to receive(:base64url_decode).with(crypto_segment).once.and_return(signature)
-    expect(JWT).to receive(:base64url_decode).at_least(:once).and_call_original
-
-    JWT.decode(jwt, secret)
-  end
-
   # no method should leave OpenSSL.errors populated
   after do
     expect(OpenSSL.errors).to be_empty

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -122,23 +122,6 @@ describe JWT do
     JWT.decode(jwt, secret)
   end
 
-  describe "secure comparison" do
-    it "returns true if strings are equal" do
-      expect(JWT.secure_compare("Foo", "Foo")).to be_true
-    end
-
-    it "returns false if either input is nil or empty" do
-      [nil, ""].each do |bad|
-        expect(JWT.secure_compare(bad, "Foo")).to be_false
-        expect(JWT.secure_compare("Foo", bad)).to be_false
-      end
-    end
-
-    it "retuns false if the strings are different" do
-      expect(JWT.secure_compare("Foo", "Bar")).to be_false
-    end
-  end
-
   # no method should leave OpenSSL.errors populated
   after do
     expect(OpenSSL.errors).to be_empty


### PR DESCRIPTION
I guess this secure comparation of two hash values isn't necessary.

According to the comment of Paŭlo Ebermann, he said:

> if the attacker does know neither the used salt nor the stored hash,
> I would guess that a timing of the comparison of calculated and stored hash will not give any information at all,
> since every (even single bit) change of the password input will result in a completely different hash.
> http://security.stackexchange.com/questions/9192/timing-attacks-on-password-hashes

So I removed secure_compare method.