### PR TITLE
Adds check for invalid exp claim

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -11,6 +11,7 @@ require "jwt/json"
 module JWT
   class DecodeError < StandardError; end
   class ExpiredSignature < StandardError; end
+  class InvalidExp < StandardError; end
   extend JWT::Json
 
   module_function
@@ -111,6 +112,7 @@ module JWT
       verify_signature(algo, key, signing_input, signature)
     end
     if options[:verify_expiration] && payload.include?('exp')
+      raise JWT::InvalidExp.new('exp is not an IntDate') unless payload['exp'].is_a?(Integer)
       raise JWT::ExpiredSignature.new("Signature has expired") unless payload['exp'] > (Time.now.to_i - options[:leeway])
     end
     return payload,header

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -129,6 +129,14 @@ describe JWT do
     jwt = JWT.encode(expired_payload, secret)
     expect { JWT.decode(jwt, secret) }.to raise_error(JWT::ExpiredSignature)
   end
+
+  it 'raises error when exp is not an IntDate' do
+    expired_payload = @payload.clone
+    expired_payload['exp'] = '2+fjkd234'
+    secret = 'secret'
+    jwt = JWT.encode(expired_payload, secret)
+    expect { JWT.decode(jwt, secret) }.to raise_error(JWT::InvalidExp)
+  end
   
   it "performs normal decode with skipped expiration check" do
     expired_payload = @payload.clone
@@ -145,6 +153,15 @@ describe JWT do
     secret = "secret"
     jwt = JWT.encode(expired_payload, secret)
     decoded_payload = JWT.decode(jwt, secret, true, {:leeway => 3})
+    expect(decoded_payload).to include(expired_payload)
+  end
+
+  it 'performs normal decode' do
+    expired_payload = @payload.clone
+    expired_payload['exp'] = Time.now.to_i + 2
+    secret = "secret"
+    jwt = JWT.encode(expired_payload, secret)
+    decoded_payload = JWT.decode(jwt, secret, true)
     expect(decoded_payload).to include(expired_payload)
   end
 


### PR DESCRIPTION
This should partially address #38.  This ensures that the exp claim is an IntDate, as required [here](http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-20#section-4.1.4).  It will raise an informative error if the claim is invalid.