### PR TITLE
Accept expiration claims as string

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'rake'
 require 'echoe'
 
-Echoe.new('jwt', '1.2.0') do |p|
+Echoe.new('jwt', '1.2.1') do |p|
   p.description    = "JSON Web Token implementation in Ruby"
   p.url            = "http://github.com/progrium/ruby-jwt"
   p.author         = "Jeff Lindsay"

--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -99,19 +99,19 @@ module JWT
 
     header, payload, signature, signing_input = decoded_segments(jwt, verify)
     raise JWT::DecodeError.new("Not enough or too many segments") unless header && payload
-    
+
     default_options = {
       :verify_expiration => true,
       :leeway => 0
     }
     options = default_options.merge(options)
-    
+
     if verify
       algo, key = signature_algorithm_and_key(header, key, &keyfinder)
       verify_signature(algo, key, signing_input, signature)
     end
     if options[:verify_expiration] && payload.include?('exp')
-      raise JWT::ExpiredSignature.new("Signature has expired") unless payload['exp'] > (Time.now.to_i - options[:leeway])
+      raise JWT::ExpiredSignature.new("Signature has expired") unless payload['exp'].to_i > (Time.now.to_i - options[:leeway])
     end
     return payload,header
   end

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -129,7 +129,15 @@ describe JWT do
     jwt = JWT.encode(expired_payload, secret)
     expect { JWT.decode(jwt, secret) }.to raise_error(JWT::ExpiredSignature)
   end
-  
+
+  it "raise ExpiredSignature even when exp claims is a string" do
+    expired_payload = @payload.clone
+    expired_payload['exp'] = (Time.now.to_i).to_s
+    secret = "secret"
+    jwt = JWT.encode(expired_payload, secret)
+    expect { JWT.decode(jwt, secret) }.to raise_error(JWT::ExpiredSignature)
+  end
+
   it "performs normal decode with skipped expiration check" do
     expired_payload = @payload.clone
     expired_payload['exp'] = Time.now.to_i - 1
@@ -138,7 +146,7 @@ describe JWT do
     decoded_payload = JWT.decode(jwt, secret, true, {:verify_expiration => false})
     expect(decoded_payload).to include(expired_payload)
   end
-  
+
   it "performs normal decode using leeway" do
     expired_payload = @payload.clone
     expired_payload['exp'] = Time.now.to_i - 2


### PR DESCRIPTION
Some Microsoft access control servers produce tokens with all claims as string. It makes the verify method crash with ArgumentError.