### PR TITLE
Add  'iss'  support for ruby-jwt

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -106,6 +106,7 @@ module JWT
     default_options = {
       :verify_expiration => true,
       :verify_not_before => true,
+      :verify_iss => true,
       :leeway => 0
     }
 
@@ -122,7 +123,7 @@ module JWT
     if options[:verify_not_before] && payload.include?('nbf')
       raise JWT::ImmatureSignature.new("Signature nbf has not been reached") unless payload['nbf'].to_i < (Time.now.to_i + options[:leeway])
     end
-    if options[:iss] && payload.include?('iss')
+    if options[:verify_iss] && payload.include?('iss')
       raise JWT::InvalidIssuerError.new("Invalid issuer") unless payload['iss'].to_s == options[:iss].to_s
     end
     return payload,header

--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -11,9 +11,9 @@ require "jwt/json"
 module JWT
   class DecodeError < StandardError; end
   class VerificationError < DecodeError; end
-  class ExpiredSignature < StandardError; end
-  class ImmatureSignature < StandardError; end
-  class InvalidIssuerError < StandardError; end
+  class ExpiredSignature < DecodeError; end
+  class ImmatureSignature < DecodeError; end
+  class InvalidIssuerError < DecodeError; end
   extend JWT::Json
 
   module_function

--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -13,6 +13,7 @@ module JWT
   class VerificationError < DecodeError; end
   class ExpiredSignature < StandardError; end
   class ImmatureSignature < StandardError; end
+  class InvalidIssuerError < StandardError; end
   extend JWT::Json
 
   module_function
@@ -107,6 +108,7 @@ module JWT
       :verify_not_before => true,
       :leeway => 0
     }
+
     options = default_options.merge(options)
 
     if verify
@@ -119,6 +121,11 @@ module JWT
     end
     if options[:verify_not_before] && payload.include?('nbf')
       raise JWT::ImmatureSignature.new("Signature nbf has not been reached") unless payload['nbf'].to_i < (Time.now.to_i + options[:leeway])
+    end
+    if options[:iss] && payload.include?('iss')
+      puts "----payload: #{payload.inspect}"
+      puts "----options: #{options.inspect}"
+      raise JWT::InvalidIssuerError.new("Invalid issuer") unless payload['iss'].to_s == options[:iss].to_s
     end
     return payload,header
   end

--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -123,8 +123,6 @@ module JWT
       raise JWT::ImmatureSignature.new("Signature nbf has not been reached") unless payload['nbf'].to_i < (Time.now.to_i + options[:leeway])
     end
     if options[:iss] && payload.include?('iss')
-      puts "----payload: #{payload.inspect}"
-      puts "----options: #{options.inspect}"
       raise JWT::InvalidIssuerError.new("Invalid issuer") unless payload['iss'].to_s == options[:iss].to_s
     end
     return payload,header

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -37,6 +37,29 @@ describe JWT do
     expect(decoded_payload).to include(example_payload)
   end
 
+  it "decodes valid JWTs with iss" do
+    example_payload = {"hello" => "world", "iss" => 'jwtiss'}
+    example_secret = 'secret'
+    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaXNzIjoiand0aXNzIn0.nTZkyYfpGUyKULaj45lXw_1gXXjHvGW4h5V7okHdUqQ'
+    decoded_payload = JWT.decode(example_jwt, example_secret, true, {iss: 'jwtiss'})
+    expect(decoded_payload).to include(example_payload)
+  end
+
+  it "raises invalid issuer" do
+    example_payload = {"hello" => "world", "iss" => 'jwtiss'}
+    example_payload2 = {"hello" => "world"}
+
+    example_secret = 'secret'
+
+    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaXNzIjoiand0aXNzIn0.nTZkyYfpGUyKULaj45lXw_1gXXjHvGW4h5V7okHdUqQ'
+    expect{ JWT.decode(example_jwt, example_secret, true, {iss: 'jwt_iss'}) }.to raise_error(JWT::InvalidIssuerError)
+
+    example_jwt2 = 'eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJoZWxsbyI6ICJ3b3JsZCJ9.tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8'
+    decode_payload2 = JWT.decode(example_jwt2, example_secret, true, {iss: 'jwt_iss'})
+    expect(decode_payload2).to include(example_payload2)
+  end
+
+
   it "raises decode exception when the token is invalid" do
     example_secret = 'secret'
     # Same as above exmaple with some random bytes replaced


### PR DESCRIPTION
add iss support,  usage (in rspec):

```ruby
example_payload = {"hello" => "world", "iss" => 'jwtiss'}
example_secret = 'secret'
example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaXNzIjoiand0aXNzIn0.nTZkyYfpGUyKULaj45lXw_1gXXjHvGW4h5V7okHdUqQ'

JWT.decode(example_jwt, example_secret, true, {iss: 'jwtiss'})

```

or

```ruby
begin
    JWT.decode(example_jwt, "secret"t, true, {iss: 'jwtiss'})
rescue JWT::InvalidIssuerError
    # Invalid issuer
end

```