### PR TITLE
Add  'iat/ aud/ sub/ jti'  support for ruby-jwt

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -152,7 +152,6 @@ module JWT
       raise JWT::InvalidJtiError.new("Not a uniq jwt id") unless options[:jti].to_s == Digest::MD5.hexdigest("#{key}:#{payload['iat']}")
     end
 
-
     return payload,header
   end
 

--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -14,6 +14,9 @@ module JWT
   class ExpiredSignature < DecodeError; end
   class ImmatureSignature < DecodeError; end
   class InvalidIssuerError < DecodeError; end
+  class InvalidIatError < DecodeError; end
+  class InvalidAudError < DecodeError; end
+  class InvalidSubError < DecodeError; end
   extend JWT::Json
 
   module_function
@@ -107,6 +110,9 @@ module JWT
       :verify_expiration => true,
       :verify_not_before => true,
       :verify_iss => true,
+      :verify_iat => true,
+      :verify_aud => true,
+      :verify_sub => true,
       :leeway => 0
     }
 
@@ -126,6 +132,20 @@ module JWT
     if options[:verify_iss] && payload.include?('iss')
       raise JWT::InvalidIssuerError.new("Invalid issuer") unless payload['iss'].to_s == options[:iss].to_s
     end
+    if options[:verify_iat] && payload.include?('iat')
+      raise JWT::InvalidIatError.new("Invalid iat") unless payload['iat'].is_a?(Numeric)
+    end
+    if options[:verify_aud] && payload.include?('aud')
+      if payload['aud'].is_a?(Array)
+        raise JWT::InvalidAudError.new("Invalid audience") unless payload['aud'].include?(options[:aud])
+      else
+        raise JWT::InvalidAudError.new("Invalid audience") unless payload['aud'].to_s == options[:aud].to_s
+      end
+    end
+    if options[:verify_sub] && payload.include?('sub')
+      raise JWT::InvalidSubError.new("Invalid subject") unless payload['sub'].to_s == options[:sub].to_s
+    end
+
     return payload,header
   end
 

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -68,10 +68,33 @@ describe JWT do
   end
 
   it "raises decode exception when iat is invalid" do
-    example_payload = {"hello" => "world", "iat" => "1425917209"}
+    example_payload = {"hello" => "world", "iat" => "abc"}
     example_secret = 'secret'
     example_jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoiMTQyNTkxNzIwOSJ9.Mn_vk61xWjIhbXFqAB0nFmNkDiCmfzUgl_LaCKRT6S8"
     expect{ JWT.decode(example_jwt, example_secret, true, {iat: 1425917209}) }.to raise_error(JWT::InvalidIatError)
+  end
+
+  it "decodes valid JWTs with jti" do
+    example_payload = {"hello" => "world", "iat" => 1425917209, "jti" => Digest::MD5.hexdigest("secret:1425917209")}
+    example_secret = 'secret'
+    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNDI1OTE3MjA5LCJqdGkiOiI1NWM3NzZlMjFmN2NiZDg3OWMwNmZhYzAxOGRhYzQwMiJ9.ET0hb-VTUOL3M22oG13ofzvGPLMAncbF8rdNDIqo8tg'
+    decoded_payload = JWT.decode(example_jwt, example_secret, true, {jti: Digest::MD5.hexdigest("secret:1425917209")})
+    expect(decoded_payload).to include(example_payload)
+  end
+
+  it "raises decode exception when jti is invalid" do
+    example_payload = {"hello" => "world", "iat" => 1425917209, "jti" => Digest::MD5.hexdigest("secret:1425917209")}
+    example_secret = 'secret'
+    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNDI1OTE3MjA5LCJqdGkiOiI1NWM3NzZlMjFmN2NiZDg3OWMwNmZhYzAxOGRhYzQwMiJ9.ET0hb-VTUOL3M22oG13ofzvGPLMAncbF8rdNDIqo8tg'
+    expect{ JWT.decode(example_jwt, example_secret, true, {jti: Digest::MD5.hexdigest("secret:1425922032")}) }.to raise_error(JWT::InvalidJtiError)
+    expect{ JWT.decode(example_jwt, example_secret) }.to raise_error(JWT::InvalidJtiError)
+  end
+
+  it "raises decode exception when jti without iat" do
+    example_payload = {"hello" => "world", "jti" => Digest::MD5.hexdigest("secret:1425917209")}
+    example_secret = 'secret'
+    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwianRpIjoiNTVjNzc2ZTIxZjdjYmQ4NzljMDZmYWMwMThkYWM0MDIifQ.n0foJCnCM_-_xUvG_TOmR9mYpL2y0UqZOD_gv33djeE'
+    expect{ JWT.decode(example_jwt, example_secret, true, {jti: Digest::MD5.hexdigest("secret:1425922032")}) }.to raise_error(JWT::InvalidJtiError)
   end
 
   it "decodes valid JWTs with aud" do

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -59,6 +59,54 @@ describe JWT do
     expect(decode_payload2).to include(example_payload2)
   end
 
+  it "decodes valid JWTs with iat" do
+    example_payload = {"hello" => "world", "iat" => 1425917209}
+    example_secret = 'secret'
+    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNDI1OTE3MjA5fQ.m4F-Ugo7aLnLunBBO3BeDidyWMx8T9eoJz6FW2rgQhU'
+    decoded_payload = JWT.decode(example_jwt, example_secret, true, {iat: true})
+    expect(decoded_payload).to include(example_payload)
+  end
+
+  it "raises decode exception when iat is invalid" do
+    example_payload = {"hello" => "world", "iat" => "1425917209"}
+    example_secret = 'secret'
+    example_jwt = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoiMTQyNTkxNzIwOSJ9.Mn_vk61xWjIhbXFqAB0nFmNkDiCmfzUgl_LaCKRT6S8"
+    expect{ JWT.decode(example_jwt, example_secret, true, {iat: 1425917209}) }.to raise_error(JWT::InvalidIatError)
+  end
+
+  it "decodes valid JWTs with aud" do
+    example_payload = {"hello" => "world", "aud" => "url:pnd"}
+    example_payload2 = {"hello" => "world", "aud" => ["url:pnd", "aud:yes"]}
+    example_secret = 'secret'
+    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiYXVkIjoidXJsOnBuZCJ9._gT5veUtNiZD7wLEC6Gd0-nkQV3cl1z8G0zXq8qcd-8'
+    example_jwt2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiYXVkIjpbInVybDpwbmQiLCJhdWQ6eWVzIl19.qNPNcT4X9B5uI91rIwbW2bIPTsp8wbRYW3jkZkrmqbQ"
+    decoded_payload = JWT.decode(example_jwt, example_secret, true, {aud: "url:pnd"})
+    decoded_payload2 = JWT.decode(example_jwt2, example_secret, true, {aud: "url:pnd"})
+    expect(decoded_payload).to include(example_payload)
+    expect(decoded_payload2).to include(example_payload2)
+  end
+
+  it "raises deode exception when aud is invalid" do
+    example_payload = {"hello" => "world", "aud" => "url:pnd"}
+    example_secret = 'secret'
+    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiYXVkIjoidXJsOnBuZCJ9._gT5veUtNiZD7wLEC6Gd0-nkQV3cl1z8G0zXq8qcd-8'
+    expect{ JWT.decode(example_jwt, example_secret, true, {aud: "wrong:aud"}) }.to raise_error(JWT::InvalidAudError)
+  end
+
+  it "decodes valid JWTs with sub" do
+    example_payload = {"hello" => "world", "sub" => 'subject'}
+    example_secret = 'secret'
+    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwic3ViIjoic3ViamVjdCJ9.QUnNVZm4SPB4vP2zY9m1LoUSOx-5oGXBhj7R89D_UtA'
+    decoded_payload = JWT.decode(example_jwt, example_secret, true, {sub: 'subject'})
+    expect(decoded_payload).to include(example_payload)
+  end
+
+  it "raise decode exception when the sub is invalid" do
+    example_payload = {"hello" => "world", "sub" => 'subject'}
+    example_secret = 'secret'
+    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwic3ViIjoic3ViamVjdCJ9.QUnNVZm4SPB4vP2zY9m1LoUSOx-5oGXBhj7R89D_UtA'
+    expect{ JWT.decode(example_jwt, example_secret, true, {iss: 'subject'}) }.to raise_error(JWT::InvalidSubError)
+  end
 
   it "raises decode exception when the token is invalid" do
     example_secret = 'secret'


### PR DESCRIPTION
# for iat check support:

```ruby
example_payload = {"hello" => "world", "iat" => 1425917209}
example_secret = 'secret'
example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNDI1OTE3MjA5fQ.m4F-Ugo7aLnLunBBO3BeDidyWMx8T9eoJz6FW2rgQhU'
decoded_payload = JWT.decode(example_jwt, example_secret, true, {iat: true})

```

or

```ruby

begin
   example_payload = {"hello" => "world", "iat" => 1425917209}
rescue JWT::InvalidIatError
   # do something
end
```

#  aud check support

```ruby

example_payload = {"hello" => "world", "aud" => "url:pnd"}
example_payload2 = {"hello" => "world", "aud" => ["url:pnd", "aud:yes"]}
example_secret = 'secret'

example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiYXVkIjoidXJsOnBuZCJ9._gT5veUtNiZD7wLEC6Gd0-nkQV3cl1z8G0zXq8qcd-8'
example_jwt2 = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiYXVkIjpbInVybDpwbmQiLCJhdWQ6eWVzIl19.qNPNcT4X9B5uI91rIwbW2bIPTsp8wbRYW3jkZkrmqbQ"

decoded_payload = JWT.decode(example_jwt, example_secret, true, {aud: "url:pnd"})
decoded_payload2 = JWT.decode(example_jwt2, example_secret, true, {aud: "url:pnd"})
```

# for sub support

```ruby
example_payload = {"hello" => "world", "sub" => 'subject'}
example_secret = 'secret'
example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwic3ViIjoic3ViamVjdCJ9.QUnNVZm4SPB4vP2zY9m1LoUSOx-5oGXBhj7R89D_UtA'
decoded_payload = JWT.decode(example_jwt, example_secret, true, {sub: 'subject'})
```

# for jti support

In order to ensure jti uniq for every jwt:

1. Use the current timestamp (iat) as the nonce.
2. Use the md5 hash of the jwt.


```ruby
example_payload = {"hello" => "world", "iat" => 1425917209, "jti" => Digest::MD5.hexdigest("secret:1425917209")}
example_secret = 'secret'
example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNDI1OTE3MjA5LCJqdGkiOiI1NWM3NzZlMjFmN2NiZDg3OWMwNmZhYzAxOGRhYzQwMiJ9.ET0hb-VTUOL3M22oG13ofzvGPLMAncbF8rdNDIqo8tg'

 decoded_payload = JWT.decode(example_jwt, example_secret, true, {jti: Digest::MD5.hexdigest("secret:1425917209")})

```


