### PR TITLE
Force verification of "iss" and "aud" claims

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -163,17 +163,17 @@ module JWT
     if options[:verify_not_before] && payload.include?('nbf')
       raise JWT::ImmatureSignature.new('Signature nbf has not been reached') unless payload['nbf'].to_i < (Time.now.to_i + options[:leeway])
     end
-    if options[:verify_iss] && payload.include?('iss')
-      raise JWT::InvalidIssuerError.new("Invalid issuer. Expected #{options['iss']}, received #{payload['iss']}") unless payload['iss'].to_s == options['iss'].to_s
+    if options[:verify_iss] && options['iss']
+      raise JWT::InvalidIssuerError.new("Invalid issuer. Expected #{options['iss']}, received #{payload['iss'] || '<none>'}") unless payload['iss'].to_s == options['iss'].to_s
     end
     if options[:verify_iat] && payload.include?('iat')
       raise JWT::InvalidIatError.new('Invalid iat') unless (payload['iat'].is_a?(Integer) and payload['iat'].to_i <= Time.now.to_i)
     end
-    if options[:verify_aud] && payload.include?('aud')
+    if options[:verify_aud] && options['aud']
       if payload['aud'].is_a?(Array)
-        raise JWT::InvalidAudError.new('Invalid audience') unless payload['aud'].include?(options['aud'])
+        raise JWT::InvalidAudError.new('Invalid audience') unless payload['aud'].include?(options['aud'].to_s)
       else
-        raise JWT::InvalidAudError.new("Invalid audience. Expected #{options['aud']}, received #{payload['aud']}") unless payload['aud'].to_s == options['aud'].to_s
+        raise JWT::InvalidAudError.new("Invalid audience. Expected #{options['aud']}, received #{payload['aud'] || '<none>'}") unless payload['aud'].to_s == options['aud'].to_s
       end
     end
     if options[:verify_sub] && payload.include?('sub')

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -83,18 +83,38 @@ describe JWT do
     expect(decoded_payload).to include(example_payload)
   end
 
-  it 'raises invalid issuer' do
-    # example_payload = {'hello' => 'world', 'iss' => 'jwtiss'}
-    example_payload2 = {'hello' => 'world'}
+  context 'issuer claim verifications' do
+    it 'raises invalid issuer when "iss" claim does not match' do
+      example_payload = {'hello' => 'world', 'iss' => 'jwtiss'}
+      example_secret = 'secret'
 
-    example_secret = 'secret'
+      example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaXNzIjoiand0aXNzIn0.nTZkyYfpGUyKULaj45lXw_1gXXjHvGW4h5V7okHdUqQ'
+      expect{ JWT.decode(example_jwt, example_secret, true, {:verify_iss => true, 'iss' => 'jwt_iss'}) }.to raise_error(JWT::InvalidIssuerError, /Expected jwt_iss, received jwtiss/)
+    end
 
-    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaXNzIjoiand0aXNzIn0.nTZkyYfpGUyKULaj45lXw_1gXXjHvGW4h5V7okHdUqQ'
-    expect{ JWT.decode(example_jwt, example_secret, true, {:verify_iss => true, 'iss' => 'jwt_iss'}) }.to raise_error(JWT::InvalidIssuerError)
+    it 'raises invalid issuer when "iss" claim is missing in payload' do
+      example_payload = {'hello' => 'world'}
+      example_secret = 'secret'
 
-    example_jwt2 = 'eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9.eyJoZWxsbyI6ICJ3b3JsZCJ9.tvagLDLoaiJKxOKqpBXSEGy7SYSifZhjntgm9ctpyj8'
-    decode_payload2 = JWT.decode(example_jwt2, example_secret, true, {'iss' => 'jwt_iss'})
-    expect(decode_payload2).to include(example_payload2)
+      example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIn0.bqxXg9VwcbXKoiWtp-osd0WKPX307RjcN7EuXbdq-CE'
+      expect{ JWT.decode(example_jwt, example_secret, true, {:verify_iss => true, 'iss' => 'jwt_iss'}) }.to raise_error(JWT::InvalidIssuerError, /received <none>/)
+    end
+
+    it 'does not raise invalid issuer when verify_iss is set to false (default option)' do
+      example_payload = {'hello' => 'world', 'iss' => 'jwtiss'}
+      example_secret = 'secret'
+
+      example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaXNzIjoiand0aXNzIn0.nTZkyYfpGUyKULaj45lXw_1gXXjHvGW4h5V7okHdUqQ'
+      expect{ JWT.decode(example_jwt, example_secret, true, {'iss' => 'jwt_iss'}) }.not_to raise_error
+    end
+
+    it 'does not raise invalid issuer when correct "iss" is in payload' do
+      example_payload = {'hello' => 'world', 'iss' => 'jwt_iss'}
+      example_secret = 'secret'
+
+      example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiaXNzIjoiand0X2lzcyJ9.mwbyRJJZJR1C5lBt8WOLg0ZMuwP9VGDf5HiQtFhd-eA'
+      expect{ JWT.decode(example_jwt, example_secret, true, {:verify_iss => true, 'iss' => 'jwt_iss'}) }.not_to raise_error
+    end
   end
 
   it 'decodes valid JWTs with iat' do
@@ -135,23 +155,32 @@ describe JWT do
     expect{ JWT.decode(example_jwt, example_secret, true, {:verify_jti => true, 'jti' => Digest::MD5.hexdigest('secret:1425922032')}) }.to raise_error(JWT::InvalidJtiError)
   end
 
-  it 'decodes valid JWTs with aud' do
-    example_payload = {'hello' => 'world', 'aud' => 'url:pnd'}
-    example_payload2 = {'hello' => 'world', 'aud' => ['url:pnd', 'aud:yes']}
-    example_secret = 'secret'
-    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiYXVkIjoidXJsOnBuZCJ9._gT5veUtNiZD7wLEC6Gd0-nkQV3cl1z8G0zXq8qcd-8'
-    example_jwt2 = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiYXVkIjpbInVybDpwbmQiLCJhdWQ6eWVzIl19.qNPNcT4X9B5uI91rIwbW2bIPTsp8wbRYW3jkZkrmqbQ'
-    decoded_payload = JWT.decode(example_jwt, example_secret, true, {'aud' => 'url:pnd'})
-    decoded_payload2 = JWT.decode(example_jwt2, example_secret, true, {'aud' => 'url:pnd'})
-    expect(decoded_payload).to include(example_payload)
-    expect(decoded_payload2).to include(example_payload2)
-  end
+  context "aud claim verifications" do
+    it 'decodes valid JWTs with aud' do
+      example_payload = {'hello' => 'world', 'aud' => 'url:pnd'}
+      example_payload2 = {'hello' => 'world', 'aud' => ['url:pnd', 'aud:yes']}
+      example_secret = 'secret'
+      example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiYXVkIjoidXJsOnBuZCJ9._gT5veUtNiZD7wLEC6Gd0-nkQV3cl1z8G0zXq8qcd-8'
+      example_jwt2 = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiYXVkIjpbInVybDpwbmQiLCJhdWQ6eWVzIl19.qNPNcT4X9B5uI91rIwbW2bIPTsp8wbRYW3jkZkrmqbQ'
+      decoded_payload = JWT.decode(example_jwt, example_secret, true, {:verify_aud => true, 'aud' => 'url:pnd'})
+      decoded_payload2 = JWT.decode(example_jwt2, example_secret, true, {:verify_aud => true, 'aud' => 'url:pnd'})
+      expect(decoded_payload).to include(example_payload)
+      expect(decoded_payload2).to include(example_payload2)
+    end
 
-  it 'raises deode exception when aud is invalid' do
-    # example_payload = {'hello' => 'world', 'aud' => 'url:pnd'}
-    example_secret = 'secret'
-    example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiYXVkIjoidXJsOnBuZCJ9._gT5veUtNiZD7wLEC6Gd0-nkQV3cl1z8G0zXq8qcd-8'
-    expect{ JWT.decode(example_jwt, example_secret, true, {:verify_aud => true, 'aud' => 'wrong:aud'}) }.to raise_error(JWT::InvalidAudError)
+    it 'raises deode exception when aud is invalid' do
+      # example_payload = {'hello' => 'world', 'aud' => 'url:pnd'}
+      example_secret = 'secret'
+      example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwiYXVkIjoidXJsOnBuZCJ9._gT5veUtNiZD7wLEC6Gd0-nkQV3cl1z8G0zXq8qcd-8'
+      expect{ JWT.decode(example_jwt, example_secret, true, {:verify_aud => true, 'aud' => 'wrong:aud'}) }.to raise_error(JWT::InvalidAudError)
+    end
+
+    it 'raises deode exception when aud is missing' do
+      # JWT.encode('hello' => 'world', 'secret')
+      example_secret = 'secret'
+      example_jwt = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIn0.bqxXg9VwcbXKoiWtp-osd0WKPX307RjcN7EuXbdq-CE'
+      expect{ JWT.decode(example_jwt, example_secret, true, {:verify_aud => true, 'aud' => 'url:pnd'}) }.to raise_error(JWT::InvalidAudError)
+    end
   end
 
   it 'decodes valid JWTs with sub' do


### PR DESCRIPTION
Previously when the following options have been provided

```ruby
   verify_iss: true, 'iss' => 'acme.org'
```

and the `"iss"` claim was missing in the payload - no verification was executed. The same was true for `"aud"`. This commit changes the behaviour, so when

```ruby
   verify_iss: true, 'iss' => 'acme.org'
```

is set - then the payload is expected to have the "iss" claim and verification will fail if missing. However, ensure to set `verify_iss` to `true`, otherwise the verification is not enabled.

This change is backwards compatible, however it might break an app here or there, because previously the verification did not happen as expected.

In addition: fixed related test cases and added new ones to ensure to cover all variants.

PS: This fixes #81 