### PR TITLE
nbf check allows exact time matches.

### DIFF
--- a/lib/jwt.rb
+++ b/lib/jwt.rb
@@ -161,7 +161,7 @@ module JWT
       fail JWT::ExpiredSignature.new('Signature has expired') unless payload['exp'].to_i > (Time.now.to_i - options[:leeway])
     end
     if options[:verify_not_before] && payload.include?('nbf')
-      fail JWT::ImmatureSignature.new('Signature nbf has not been reached') unless payload['nbf'].to_i < (Time.now.to_i + options[:leeway])
+      fail JWT::ImmatureSignature.new('Signature nbf has not been reached') unless payload['nbf'].to_i <= (Time.now.to_i + options[:leeway])
     end
     if options[:verify_iss] && options['iss']
       fail JWT::InvalidIssuerError.new("Invalid issuer. Expected #{options['iss']}, received #{payload['iss'] || '<none>'}") unless payload['iss'].to_s == options['iss'].to_s

--- a/spec/jwt_spec.rb
+++ b/spec/jwt_spec.rb
@@ -362,6 +362,15 @@ describe JWT do
     expect { JWT.decode(jwt, secret) }.to raise_error(JWT::ImmatureSignature)
   end
 
+  it 'doesnt raise error when equal to nbf' do
+    mature_payload = @payload.clone
+    mature_payload['nbf'] = Time.now.to_i
+    secret = 'secret'
+    jwt = JWT.encode(mature_payload, secret)
+    decoded_payload = JWT.decode(jwt, secret, true, :verify_expiration => false)
+    expect(decoded_payload).to include(mature_payload)
+  end
+
   it 'doesnt raise error when after nbf' do
     mature_payload = @payload.clone
     secret = 'secret'
@@ -372,7 +381,7 @@ describe JWT do
 
   it 'raise ImmatureSignature even when nbf claim is a string' do
     immature_payload = @payload.clone
-    immature_payload['nbf'] = (Time.now.to_i).to_s
+    immature_payload['nbf'] = (Time.now.to_i + 1).to_s
     secret = 'secret'
     jwt = JWT.encode(immature_payload, secret)
     expect { JWT.decode(jwt, secret) }.to raise_error(JWT::ImmatureSignature)


### PR DESCRIPTION
From the spec "The nbf (not before) claim identifies the time before which the JWT MUST NOT be accepted for processing.". The exact time is not before itself, so it should be valid.

This was annoying me in unit tests in a project of mine.