### PR TITLE
Fix missing verify parameter in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ exp_payload = { :data => 'data', :exp => exp }
 token = JWT.encode exp_payload, hmac_secret, 'HS256'
 
 begin
-  decoded_token = JWT.decode token, hmac_secret
+  decoded_token = JWT.decode token, hmac_secret, true
 rescue JWT::ExpiredSignature
   # Handle expired token, e.g. logout user or deny access
 end


### PR DESCRIPTION
The docs were missing the 3rd parameter to decode which enables verification in the first expiration example.

Let to some head scratching on my part until I noticed it in the second example, and went looking in `jwt.rb` to see what it did.